### PR TITLE
🔧 Fix agent directory creation issue

### DIFF
--- a/repo_tickets/agents.py
+++ b/repo_tickets/agents.py
@@ -27,16 +27,24 @@ class AgentStorage:
         self.agents_dir = self.ticket_storage.tickets_dir / "agents"
         self.tasks_dir = self.ticket_storage.tickets_dir / "tasks"
         
-        # Ensure directories exist
-        self.agents_dir.mkdir(exist_ok=True)
-        self.tasks_dir.mkdir(exist_ok=True)
+        # Ensure directories exist if ticket storage is initialized
+        if self.ticket_storage.is_initialized():
+            self.agents_dir.mkdir(exist_ok=True)
+            self.tasks_dir.mkdir(exist_ok=True)
     
     def is_initialized(self) -> bool:
         """Check if the agent system is initialized."""
         return self.ticket_storage.is_initialized() and self.agents_dir.exists()
     
+    def _ensure_directories(self) -> None:
+        """Ensure agent directories exist."""
+        if self.ticket_storage.is_initialized():
+            self.agents_dir.mkdir(exist_ok=True)
+            self.tasks_dir.mkdir(exist_ok=True)
+    
     def save_agent(self, agent: Agent) -> None:
         """Save an agent to storage."""
+        self._ensure_directories()
         agent_file = self.agents_dir / f"{agent.id}.json"
         
         try:
@@ -97,6 +105,7 @@ class AgentStorage:
     
     def save_task(self, task: AgentTask) -> None:
         """Save an agent task to storage."""
+        self._ensure_directories()
         task_file = self.tasks_dir / f"{task.id}.json"
         
         try:


### PR DESCRIPTION
## 📋 Summary
This PR fixes an issue where agent commands would fail if the agent directories didn't exist yet.

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📝 Changes Made
- Add `_ensure_directories()` method to create agent and task directories when needed
- Update `save_agent` and `save_task` methods to call directory creation
- Ensures backwards compatibility with existing ticket systems

## 🧪 Testing
- [x] Verified agent creation works on fresh ticket systems
- [x] Verified existing functionality remains unaffected
- [x] Tested directory creation is idempotent (safe to call multiple times)

This ensures the agent system works seamlessly from the first use without requiring manual directory creation.